### PR TITLE
Fix header indentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#schnoog/mediatelegram
+# schnoog/mediatelegram
 
-##https://github.com/schnoog/mediatelegram
+## https://github.com/schnoog/mediatelegram
 
-#Telegram-Bot for videofiles download
+# Telegram-Bot for videofiles download
 - [x] Youtube (Video & mp3)
 - [x] Twitter (Video)
 - [x] Facebook (Video)
 - [x] Misc. other video platforms (supported by youtube-dl)
 
-##Requirements
+## Requirements
 - [x] php >= 5.5
 - [x] Composer
 - [x] MySQL-datebase
@@ -18,18 +18,23 @@
 - [ ] Webserver with valid SSL certificate (for webhook)
 
 
-##Installation
-###Get the files
-#####Composer only
+## Installation
+
+### Get the files
+
+##### Composer only
+
 `composer create-project schnoog/mediatelegram`
-#####Git & Composer
+
+##### Git & Composer
+
 -Create the target directory and cd into it
 -Clone this repo
 `git clone https://github.com/schnoog/mediatelegram.git .`
 -Install the composer depencies
 `composer install`
 
-###Prepare & Config
+### Prepare & Config
 
 1.  Import the structure.sql delivered with telegram-bot
 `./vendor/longman/telegram-bot/structure.sql`
@@ -38,13 +43,17 @@
 3.  Create and edit the config.php
 `cp include/config.php.dist include/config.php`
 
-##Usage
-###Manual call
+## Usage
+
+### Manual call
+
 Simply open the getUpdatesCLI.php
 `php getUpdatesCLI.php`
 or open it in you browser on your webserver
 getUpdatesCLI.php
-###Webhook
+
+### Webhook
+
 Open the sethook.php with supplied secret $Config['seccode'] in your browser
 `https://YourBotsURL/sethook.php?secret=YourSecret`
 This will install the webhook and every new command sent to the server will be processed


### PR DESCRIPTION
GitHuB doesn't accept titles(/headings) written without a space after the hash-char, so add them all! :books: :lipstick:
Fixes also some possible rendering bugs with pandoc(intendation between headings/titles and text) :art: